### PR TITLE
Improve error handling of checkPot task

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -97,18 +97,6 @@ build_script:
  - 'echo scons args: %sconsArgs%'
  - scons source %sconsArgs%
  - if ERRORLEVEL 1 exit %ERRORLEVEL%
- # We don't need launcher to run checkPot, so run the checkPot before launcher.
- - ps: |
-     cmd.exe /c "scons checkPot $sconsArgs"
-     if($LastExitCode -ne 0) {
-      $errorCode=$LastExitCode
-      Add-AppveyorMessage "Translation comments missing or unexpectedly included."
-     }
-     if ($errorCode -ne 0) { $host.SetShouldExit($errorCode) }
- # The pot gets built by tests, but we don't actually need it as a build artifact.
- - 'echo scons output targets: %sconsOutTargets%'
- - scons %sconsOutTargets% %sconsArgs%
- - if ERRORLEVEL 1 exit %ERRORLEVEL%
  # Build symbol store.
  - ps: |
      foreach ($syms in
@@ -175,6 +163,18 @@ test_script:
      $wc = New-Object 'System.Net.WebClient'
      $wc.UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", $unitTestsXml)
      if($errorCode -ne 0) { $host.SetShouldExit($errorCode) }
+
+ - ps: |
+     cmd.exe /c "scons checkPot $sconsArgs"
+     if($LastExitCode -ne 0) {
+      $errorCode=$LastExitCode
+      Add-AppveyorMessage "Translation comments missing or unexpectedly included."
+     }
+     if ($errorCode -ne 0) { $host.SetShouldExit($errorCode) }
+ # The pot gets built by tests, but we don't actually need it as a build artifact.
+ - 'echo scons output targets: %sconsOutTargets%'
+ - scons %sconsOutTargets% %sconsArgs%
+ - if ERRORLEVEL 1 exit %ERRORLEVEL%
 
 # Flake8 Linting
  - ps: |

--- a/sconstruct
+++ b/sconstruct
@@ -432,9 +432,30 @@ def makePotSourceFileList(target, sourceFiles, env):
 		fileList.writelines([f + '\n' for f in potSourceFiles])
 
 
-def makePot(target, source, env):
+env.SConscript("devDocs/sconscript", exports=["env", "outputDir", "sourceDir", "t2tBuildConf"])
+
+def getSubDirs(path):
+	for root, dirNames, fileNames in os.walk(path):
+		yield root
+
+def makePot(target, source, env):	
+	# The Glob() SCons function doesnt have the ability to go recursive. Instead
+	# walk the dirs and match patterns.
+	potSourceFiles = [
+		# Don't use sourceDir as the source, as this depends on comInterfaces and nvdaHelper.
+		# We only depend on the Python files.
+		f for recurseDirs in getSubDirs(str(source[0]))
+		for pattern in ("*.py", "*.pyw")
+		for f in env.Glob(
+			os.path.join(recurseDirs, pattern),
+			# Exclude comInterfaces, since these don't contain translatable strings
+			# and they cause unknown encoding warnings.
+			exclude="source/comInterfaces/*"
+		)
+	]
+
 	potSourceFileList = outputDir.File("potSourceFileList.txt")
-	makePotSourceFileList(potSourceFileList, source, env)
+	makePotSourceFileList(potSourceFileList, potSourceFiles, env)
 	# Generate the pot.
 	if env.Execute([
 		[
@@ -471,32 +492,9 @@ def makePot(target, source, env):
 	os.rename(tmpFn, potFn)
 
 
-env.SConscript("devDocs/sconscript", exports=["env", "outputDir", "sourceDir", "t2tBuildConf"])
-
-
-def getSubDirs(path):
-	for root, dirNames, fileNames in os.walk(path):
-		yield root
-
-
-# The Glob() SCons function doesnt have the ability to go recursive. Instead
-# walk the dirs and match patterns.
-potSourceFiles = [
-	# Don't use sourceDir as the source, as this depends on comInterfaces and nvdaHelper.
-	# We only depend on the Python files.
-	f for recurseDirs in getSubDirs(sourceDir.path)
-	for pattern in ("*.py", "*.pyw")
-	for f in env.Glob(
-		os.path.join(recurseDirs, pattern),
-		# Exclude comInterfaces, since these don't contain translatable strings
-		# and they cause unknown encoding warnings.
-		exclude="source/comInterfaces/*"
-	)
-]
-
 pot = env.Command(
 	outputDir.File("%s.pot" % outFilePrefix),
-	potSourceFiles,
+	sourceDir.path,
 	makePot
 )
 


### PR DESCRIPTION
This address the remaining issues with NVDA issue nvaccess#10928.

The two issues addressed are:

makePot is print the names of many files during the scons pot command.
checkPot is running earlier in than the unit tests during the AppVeyor CI build.
To fix the makePot issue the code in sconstruct was refactored a bit. The file names are logged by the Env.Command function call, which echos the input parameters to the console. The input parameter is a list of files that were discovered by a recursive directory search of the source code. The refactor moves the directory search into the makePot method and updates the parameter to be the directory to be searched, rather than the result of the search.

To fix the order of the CI build the AppVeyor file was updated to move the task to run the checkPot test below the unit test step. The issue mentioned that this update is really more of a judgement call based on which task should be prioritized.